### PR TITLE
Remove -lstdc++ flags

### DIFF
--- a/demo/Makefile.am
+++ b/demo/Makefile.am
@@ -10,8 +10,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/lib \
 	-I$(top_srcdir)/gnome/include \
 	@LIBGDKPIXBUF_CFLAGS@ @BOOST_CPPFLAGS@
 
-LIBOPENRAW_LIBS = ../lib/libopenraw.la -lstdc++ -ljpeg
-LIBOPENRAWGNOME_LIBS = ../gnome/libopenrawgnome.la -lstdc++ -ljpeg \
+LIBOPENRAW_LIBS = ../lib/libopenraw.la -ljpeg
+LIBOPENRAWGNOME_LIBS = ../gnome/libopenrawgnome.la -ljpeg \
 	@LIBGDKPIXBUF_LIBS@
 
 extensions_LDADD = $(LIBOPENRAW_LIBS)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -6,5 +6,5 @@ noinst_PROGRAMS = ordiag
 
 
 ordiag_SOURCES = ordiag.cpp
-ordiag_LDADD = $(top_builddir)/lib/libopenraw.la  -lstdc++ -ljpeg
+ordiag_LDADD = $(top_builddir)/lib/libopenraw.la -ljpeg
 ordiag_LDFLAGS = -L$(top_builddir)/lib -static


### PR DESCRIPTION
The C++ compiler already knows what C++ stdlib to use (and there are systems where it’s not libstdc++).