### PR TITLE
Update libopenraw-gnome-0.3.pc.in

### DIFF
--- a/gnome/libopenraw-gnome-0.3.pc.in
+++ b/gnome/libopenraw-gnome-0.3.pc.in
@@ -6,7 +6,7 @@ VERSION=@VERSION@
 
 Name: libopenraw-gnome
 Description: Library for easy decoding of camera RAW files. Gnome support.
-Requires: libopenraw-0.1
+Requires: libopenraw-0.3
 Version: @VERSION@
 Libs: -L${libdir} -lopenraw -lopenrawgnome
 Cflags: -I${includedir}/@LIBOPENRAW_INCLUDE_BASE@ -I${includedir}


### PR DESCRIPTION
Updating the _Requires_ to libopenraw-0.3: it presently looks for libopenraw-0.1, which won't exist when this is installed.